### PR TITLE
db8: Roles: Add back outbound permissions for com.webos.service.attac…

### DIFF
--- a/files/sysbus/dynamic/com.palm.db.role.json.in
+++ b/files/sysbus/dynamic/com.palm.db.role.json.in
@@ -5,15 +5,15 @@
     "permissions": [
         {
             "service":"com.palm.db",
-            "outbound":["com.webos.service.activitymanager.client", "com.palm.service.backup", "com.palm.systemmanager", "com.palm.configurator", "com.palm.activitymanager", "com.webos.settingsservice", "org.webosports.luna", "org.webosinternals.tweaks.prefs", "org.webosports.app.phone", "com.palm.service.accounts", "com.webos.lunasend-*", "com.webos.monitor", "com.palm.imap", "com.palm.smtp", "com.palm.pop", "org.webosports.app.browser", "org.webosports.mediaindexer", "org.webosports.cdav.service", "com.palm.service.contacts.linker"]
+            "outbound":["com.webos.service.activitymanager.client", "com.palm.service.backup", "com.palm.systemmanager", "com.palm.configurator", "com.palm.activitymanager", "com.webos.service.attachedstoragemanager", "com.webos.settingsservice", "org.webosports.luna", "org.webosinternals.tweaks.prefs", "org.webosports.app.phone", "com.palm.service.accounts", "com.webos.lunasend-*", "com.webos.monitor", "com.palm.imap", "com.palm.smtp", "com.palm.pop", "org.webosports.app.browser", "org.webosports.mediaindexer", "org.webosports.cdav.service", "com.palm.service.contacts.linker"]
         },
         {
             "service":"com.palm.tempdb",
-            "outbound":["com.webos.service.activitymanager.client", "com.palm.activitymanager", "com.palm.systemmanager", "com.palm.configurator", "com.palm.activitymanager", "com.webos.settingsservice", "org.webosports.luna", "org.webosinternals.tweaks.prefs", "org.webosports.app.phone", "com.palm.service.accounts", "com.webos.lunasend-*", "com.webos.monitor", "com.palm.imap", "com.palm.smtp", "com.palm.pop", "org.webosports.app.browser", "org.webosports.mediaindexer", "org.webosports.cdav.service", "com.palm.service.contacts.linker"]
+            "outbound":["com.webos.service.activitymanager.client", "com.palm.activitymanager", "com.palm.systemmanager", "com.palm.configurator", "com.palm.activitymanager", "com.webos.service.attachedstoragemanager", "com.webos.settingsservice", "org.webosports.luna", "org.webosinternals.tweaks.prefs", "org.webosports.app.phone", "com.palm.service.accounts", "com.webos.lunasend-*", "com.webos.monitor", "com.palm.imap", "com.palm.smtp", "com.palm.pop", "org.webosports.app.browser", "org.webosports.mediaindexer", "org.webosports.cdav.service", "com.palm.service.contacts.linker"]
         },
         {
             "service":"com.webos.mediadb",
-            "outbound":["com.webos.service.activitymanager.client", "com.palm.activitymanager", "com.palm.systemmanager", "com.palm.configurator", "com.palm.activitymanager", "com.webos.settingsservice", "org.webosports.luna", "org.webosinternals.tweaks.prefs", "org.webosports.app.phone", "com.palm.service.accounts", "com.webos.lunasend-*", "com.webos.monitor", "com.palm.imap", "com.palm.smtp", "com.palm.pop", "org.webosports.app.browser", "org.webosports.mediaindexer", "org.webosports.cdav.service", "com.palm.service.contacts.linker"]
+            "outbound":["com.webos.service.activitymanager.client", "com.palm.activitymanager", "com.palm.systemmanager", "com.palm.configurator", "com.palm.activitymanager", "com.webos.service.attachedstoragemanager", "com.webos.settingsservice", "org.webosports.luna", "org.webosinternals.tweaks.prefs", "org.webosports.app.phone", "com.palm.service.accounts", "com.webos.lunasend-*", "com.webos.monitor", "com.palm.imap", "com.palm.smtp", "com.palm.pop", "org.webosports.app.browser", "org.webosports.mediaindexer", "org.webosports.cdav.service", "com.palm.service.contacts.linker"]
         }
     ]
 }

--- a/files/sysbus/dynamic/com.webos.db8.test.media.role.json.in
+++ b/files/sysbus/dynamic/com.webos.db8.test.media.role.json.in
@@ -5,7 +5,7 @@
     "permissions": [
         {
             "service":"com.webos.db8.test.media",
-            "outbound":["*"]
+            "outbound":["com.webos.service.attachedstoragemanager"]
         }
     ]
 }

--- a/files/sysbus/static/com.palm.db.role.json.in
+++ b/files/sysbus/static/com.palm.db.role.json.in
@@ -5,15 +5,15 @@
     "permissions": [
         {
             "service":"com.palm.db",
-            "outbound":["com.webos.service.activitymanager.client", "com.palm.service.backup", "com.palm.systemmanager", "com.palm.configurator", "com.palm.activitymanager", "com.webos.settingsservice", "org.webosports.luna", "org.webosinternals.tweaks.prefs", "org.webosports.app.phone", "com.palm.service.accounts", "com.webos.lunasend-*", "com.webos.monitor", "com.palm.imap", "com.palm.smtp", "com.palm.pop", "org.webosports.app.browser", "org.webosports.mediaindexer", "org.webosports.cdav.service", "com.palm.service.contacts.linker"]
+            "outbound":["com.webos.service.activitymanager.client", "com.palm.service.backup", "com.palm.systemmanager", "com.palm.configurator", "com.palm.activitymanager", "com.webos.service.attachedstoragemanager", "com.webos.settingsservice", "org.webosports.luna", "org.webosinternals.tweaks.prefs", "org.webosports.app.phone", "com.palm.service.accounts", "com.webos.lunasend-*", "com.webos.monitor", "com.palm.imap", "com.palm.smtp", "com.palm.pop", "org.webosports.app.browser", "org.webosports.mediaindexer", "org.webosports.cdav.service", "com.palm.service.contacts.linker"]
         },
         {
             "service":"com.palm.tempdb",
-            "outbound":["com.webos.service.activitymanager.client", "com.palm.activitymanager", "com.palm.systemmanager", "com.palm.configurator", "com.palm.activitymanager", "com.webos.settingsservice", "org.webosports.luna", "org.webosinternals.tweaks.prefs", "org.webosports.app.phone", "com.palm.service.accounts", "com.webos.lunasend-*", "com.webos.monitor", "com.palm.imap", "com.palm.smtp", "com.palm.pop", "org.webosports.app.browser", "org.webosports.mediaindexer", "org.webosports.cdav.service", "com.palm.service.contacts.linker"]
+            "outbound":["com.webos.service.activitymanager.client", "com.palm.activitymanager", "com.palm.systemmanager", "com.palm.configurator", "com.palm.activitymanager", "com.webos.service.attachedstoragemanager", "com.webos.settingsservice", "org.webosports.luna", "org.webosinternals.tweaks.prefs", "org.webosports.app.phone", "com.palm.service.accounts", "com.webos.lunasend-*", "com.webos.monitor", "com.palm.imap", "com.palm.smtp", "com.palm.pop", "org.webosports.app.browser", "org.webosports.mediaindexer", "org.webosports.cdav.service", "com.palm.service.contacts.linker"]
         },
         {
             "service":"com.webos.mediadb",
-            "outbound":["com.webos.service.activitymanager.client", "com.palm.activitymanager", "com.palm.systemmanager", "com.palm.configurator", "com.palm.activitymanager", "com.webos.settingsservice", "org.webosports.luna", "org.webosinternals.tweaks.prefs", "org.webosports.app.phone", "com.palm.service.accounts", "com.webos.lunasend-*", "com.webos.monitor", "com.palm.imap", "com.palm.smtp", "com.palm.pop", "org.webosports.app.browser", "org.webosports.mediaindexer", "org.webosports.cdav.service", "com.palm.service.contacts.linker"]
+            "outbound":["com.webos.service.activitymanager.client", "com.palm.activitymanager", "com.palm.systemmanager", "com.palm.configurator", "com.palm.activitymanager", "com.webos.service.attachedstoragemanager", "com.webos.settingsservice", "org.webosports.luna", "org.webosinternals.tweaks.prefs", "org.webosports.app.phone", "com.palm.service.accounts", "com.webos.lunasend-*", "com.webos.monitor", "com.palm.imap", "com.palm.smtp", "com.palm.pop", "org.webosports.app.browser", "org.webosports.mediaindexer", "org.webosports.cdav.service", "com.palm.service.contacts.linker"]
         }
     ]
 }

--- a/files/sysbus/static/com.webos.db8.test.media.role.json.in
+++ b/files/sysbus/static/com.webos.db8.test.media.role.json.in
@@ -5,7 +5,7 @@
     "permissions": [
         {
             "service":"com.webos.db8.test.media",
-            "outbound":["*"]
+            "outbound":["com.webos.service.attachedstoragemanager"]
         }
     ]
 }


### PR DESCRIPTION
…hedstoragemanager

Since we now have PDM, we can add this back. Reverts https://github.com/webOS-ports/db8/commit/2587b360bad0135ddcbec17dcc17ca97b032b5b1

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>