### PR TITLE
Add permissions for com.webos.service.attachedstoragemanager

### DIFF
--- a/files/conf/mediadb.conf.in
+++ b/files/conf/mediadb.conf.in
@@ -17,7 +17,8 @@
 			{"type":"db.role","object":"admin","caller":"com.palm.service.backup","operations":{"*":"allow"}},
 			{"type":"db.role","object":"admin","caller":"com.palm.odd.service","operations":{"*":"allow"}},
 			{"type":"db.role","object":"admin","caller":"com.palm.service.migrationscript","operations":{"*":"allow"}},
-			{"type":"db.role","object":"admin","caller":"com.palm.spacecadet","operations":{"*":"allow"}}
+			{"type":"db.role","object":"admin","caller":"com.palm.spacecadet","operations":{"*":"allow"}},
+			{"type":"db.role","object":"admin","caller":"com.webos.service.attachedstoragemanager","operations":{"*":"allow"}}
 		],
 		"quotas" : [
 			{"owner":"*","size":10485760},


### PR DESCRIPTION
Fixes:

Jun 24 16:49:37 qemux86-64 ls-hubd[290]: [] [pmlog] ls-hubd LSHUB_NOT_LSTED {"SERVICE_NAME":"com.webos.service.attachedstoragemanager","EXE":"/usr/sbin/mojodb-luna","APP_ID":"(null)","PID":552} Service not listed in service files (cmdline: /usr/sbin/mojodb-luna -c /etc/palm/db8/mediadb.conf)

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>